### PR TITLE
Update eslintrc for eslint2, update all pkgs for remark4

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@ rules:
     dot-notation: [2]
     eqeqeq: [2]
     handle-callback-err: [2]
+    keyword-spacing: [2]
     new-cap: [2]
     new-parens: [2]
     no-alert: [2]
@@ -37,13 +38,16 @@ rules:
     radix: [2]
     semi: [2, 'always']
     semi-spacing: [2]
-    space-after-keywords: [2, 'always']
     space-before-function-paren: [2, 'always']
     space-before-blocks: [2, 'always']
-    space-return-throw-case: [2]
     spaced-comment: [2, 'always']
     strict: [2, 'global']
     yoda: [2, 'never']
 
 env:
+    es6: true
     node: true
+
+parserOptions:
+    ecmaVersion: 6
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-remark",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Convert markdown to html with remark",
   "license": "MIT",
   "homepage": "https://github.com/ben-eb/metalsmith-remark",

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
   ],
   "main": "index.js",
   "dependencies": {
-    "remark": "^4.0.0",
+    "remark": "^4.1.0",
     "remark-html": "^3.0.0"
   },
   "devDependencies": {
     "assert-dir-equal": "^1.0.1",
     "ava": "^0.11.0",
-    "eslint": "^2.0.0",
+    "eslint": "^2.1.0",
     "metalsmith": "^2.1.0",
     "remark-squeeze-paragraphs": "^3.0.0",
     "remark-strip-badges": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -15,16 +15,16 @@
   ],
   "main": "index.js",
   "dependencies": {
-    "remark": "^3.1.3",
-    "remark-html": "^2.0.2"
+    "remark": "^4.0.0",
+    "remark-html": "^3.0.0"
   },
   "devDependencies": {
     "assert-dir-equal": "^1.0.1",
     "ava": "^0.11.0",
-    "eslint": "^1.10.3",
+    "eslint": "^2.0.0",
     "metalsmith": "^2.1.0",
     "remark-squeeze-paragraphs": "^3.0.0",
-    "remark-strip-badges": "^2.0.0"
+    "remark-strip-badges": "^3.0.0"
   },
   "keywords": [
     "markdown",


### PR DESCRIPTION
The greenkeeper PRs only failed because ALL remark deps need to updated for remark 4.0.0
