### PR TITLE
Update for remark@8.0.0 and remark-html@6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "dist"
   ],
   "dependencies": {
-    "remark": "^5.0.1",
-    "remark-html": "^5.0.0"
+    "remark": "^8.0.0",
+    "remark-html": "^6.0.1"
   },
   "devDependencies": {
     "assert-dir-equal": "^1.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -3,18 +3,19 @@ import remark from 'remark';
 import html from 'remark-html';
 
 export default function metalsmithRemark (plugins) {
-    return function (files) {
-        Object.keys(files).map(file => {
+    return function (files, metal, done) {
+        Promise.all(Object.keys(files).map(file => {
             const extension = extname(file);
             if (extension !== '.md' && extension !== '.markdown') {
                 return true;
             }
             const markdown = String(files[file].contents);
-            const result = remark().use(plugins).use(html).process(markdown);
-            files[file].contents = new Buffer(result.contents);
-            const data = files[file];
-            delete files[file];
-            files[file.replace(extension, '.html')] = data;
-        });
+            return remark().use(plugins).use(html).process(markdown).then(result => {
+                files[file].contents = new Buffer(result.contents);
+                const data = files[file];
+                delete files[file];
+                files[file.replace(extension, '.html')] = data;
+            });
+        })).then(() => done());
     };
 }


### PR DESCRIPTION
Good day!

I discovered this project while searching for a metalsmith plugin that could allow me to use a specific remark plugin in a personal project. This seemed like exactly the solution I needed, but as it turns out the plugin I wanted to use depended on a newer, incompatible version of remark.

Here is my take on updating metalsmith-remark to make use of the most recent versions of the packages. It involves wrapping the remark file processing in a promise and letting metalsmith run the plugin in an async manner.

Thank you for your time!